### PR TITLE
Fix rpath entry

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Aperture",
-        "repositoryURL": "/Users/dac09/Code/aperture-group/Aperture",
+        "repositoryURL": "https://github.com/tapehq/Aperture",
         "state": {
           "branch": "try/5.2.0+scalefactor",
           "revision": "a5d460104726e0205f903ab988a1ecf91ea46eb2",

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "../Aperture", .branch("try/5.2.0+scalefactor"))
+    .package(url: "https://github.com/tapehq/Aperture", .branch("try/5.2.0+scalefactor")),
   ],
   targets: [
     .target(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aperture",
-  "version": "5.3.1-sf.4",
+  "version": "5.3.2-sf.4",
   "description": "Record the screen on macOS",
   "license": "MIT",
   "repository": "wulkano/aperture-node",
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "xo && ava",
-    "build": "swift build --configuration=release --static-swift-stdlib -Xswiftc '-target' -Xswiftc 'x86_64-apple-macosx10.12' && mv .build/release/aperture .",
+    "build": "swift build --configuration=release --static-swift-stdlib -Xswiftc '-target' -Xswiftc 'x86_64-apple-macosx10.12' && mv .build/release/aperture . && install_name_tool -delete_rpath /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx aperture",
     "build:pack": "yarn build && yarn version --prerelease --preid sf --no-git-tag-version && yarn pack",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
- Updated build step to cleanup wrong rPath entry
- Update Package.swift to point tapehq/Aperture as dependecy 